### PR TITLE
Generate public populateCache methods

### DIFF
--- a/generate/cache_service_tpl.go
+++ b/generate/cache_service_tpl.go
@@ -77,7 +77,8 @@ public class {{ .Name }}CacheService extends CacheService<{{ .Name }}Resource> {
 		populateCache(orgId);
 	}
 
-    private void populateCache(String orgId) {
+    @Override
+    public void populateCache(String orgId) {
 		log.info("Populating {{ .Name }} cache for {}", orgId);
         Event event = new Event(orgId, Constants.COMPONENT, {{ GetAction .Package}}.GET_ALL_{{ ToUpper .Name }}, Constants.CACHE_SERVICE);
         consumerEventUtil.send(event);


### PR DESCRIPTION
Ref https://github.com/FINTLabs/fint-cache/pull/17, this is required to enable consumers to populate caches on creation.