### PR TITLE
Added support for choosing a specific tag or branch of skeleton.

### DIFF
--- a/commands.go
+++ b/commands.go
@@ -90,6 +90,15 @@ var Commands = []cli.Command{
 				Name:  "includePerson",
 				Usage: "Include person model",
 			},
+			cli.StringFlag{
+				Name:  "branch",
+				Usage: "branch of skeleton project to use",
+				Value: "master",
+			},
+			cli.StringFlag{
+				Name:  "tag",
+				Usage: "tag of skeleton project to use",
+			},
 		},
 	},
 }

--- a/common/github/clone.go
+++ b/common/github/clone.go
@@ -1,18 +1,24 @@
 package github
 
 import (
+	"errors"
 	"fmt"
 	"os"
-	"gopkg.in/src-d/go-git.v4"
-	"errors"
+
 	"github.com/FINTLabs/fint-consumer/common/utils"
+	"gopkg.in/src-d/go-git.v4"
+	"gopkg.in/src-d/go-git.v4/plumbing"
 )
 
-func Clone(name string, cloneUrl string) error  {
+func Clone(name string, cloneUrl string, reference string) error {
+
+	ref := plumbing.ReferenceName(reference)
 
 	r, err := git.PlainClone(utils.GetWorkingDir(name), false, &git.CloneOptions{
-		URL:      cloneUrl,
-		Progress: os.Stdout,
+		URL:           cloneUrl,
+		Progress:      os.Stdout,
+		Depth:         1,
+		ReferenceName: ref,
 	})
 
 	_, err = r.Head()

--- a/setup/command.go
+++ b/setup/command.go
@@ -34,7 +34,14 @@ func CmdSetupConsumer(c *cli.Context) {
 	component := c.String("component")
 	verfifyParameter(component, "Component parameter missing!")
 
-	setupSkeleton(name)
+	var ref string
+	if c.String("tag") != "" {
+		ref = "refs/tags/" + c.String("tag")
+	} else {
+		ref = "refs/heads/" + c.String("branch")
+	}
+
+	setupSkeleton(name, ref)
 	generate.Generate(c.GlobalString("owner"), c.GlobalString("repo"), tag, c.GlobalString("filename"), force)
 
 	addModels(component, pkg, name)

--- a/setup/skeleton.go
+++ b/setup/skeleton.go
@@ -2,16 +2,17 @@ package setup
 
 import (
 	"fmt"
+	"io/ioutil"
 	"os"
 	"path/filepath"
-	"io/ioutil"
 	"strings"
+
+	"github.com/FINTLabs/fint-consumer/common/config"
 	"github.com/FINTLabs/fint-consumer/common/github"
 	"github.com/FINTLabs/fint-consumer/common/utils"
-	"github.com/FINTLabs/fint-consumer/common/config"
 )
 
-func setupSkeleton(name string) {
+func setupSkeleton(name string, reference string) {
 
 	consumerName := getConsumerName(name)
 	shortConsumerName := strings.Replace(consumerName, "fint-", "", -1)
@@ -21,9 +22,9 @@ func setupSkeleton(name string) {
 
 	os.RemoveAll(utils.GetWorkingDir(consumerName))
 
-	fmt.Printf("  > Cloning repository %s ...\n", config.CONSUMER_SKELETON_URL)
+	fmt.Printf("  > Cloning repository %s, %s ...\n", config.CONSUMER_SKELETON_URL, reference)
 
-	err := github.Clone(consumerName, config.CONSUMER_SKELETON_URL)
+	err := github.Clone(consumerName, config.CONSUMER_SKELETON_URL, reference)
 	if err != nil {
 		fmt.Println(err)
 		os.Exit(-1)
@@ -33,7 +34,7 @@ func setupSkeleton(name string) {
 	os.RemoveAll(utils.GetDotGitDir(consumerName))
 
 	fmt.Println("--> Renaming project ...")
-	err = filepath.Walk(utils.GetWorkingDir(consumerName), func (path string, fi os.FileInfo, err error) error {
+	err = filepath.Walk(utils.GetWorkingDir(consumerName), func(path string, fi os.FileInfo, err error) error {
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
The `setup` command has two new options, `--tag` and `--branch`, which can be used to select a specific tag (or branch) of https://github.com/FINTLabs/fint-consumer-skeleton to setup the new consumer from.

The default is still to setup from the `master` branch.