### PR TITLE
Add support for disabling cache services

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -1,0 +1,1 @@
+docker build -t fint-consumer --build-arg VERSION=0.$(Get-Date -Format yyMMdd.HHmm) .

--- a/generate/cache_service_tpl.go
+++ b/generate/cache_service_tpl.go
@@ -18,6 +18,7 @@ import no.fint.relations.FintResourceCompatibility;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 
@@ -32,6 +33,7 @@ import {{ GetIdentifikatorPackage .Imports }};
 
 @Slf4j
 @Service
+@ConditionalOnProperty(name = "fint.consumer.cache.disabled.{{ ToLower .Name }}", havingValue = "false", matchIfMissing = true)
 public class {{ .Name }}CacheService extends CacheService<{{ .Name }}Resource> {
 
     public static final String MODEL = {{ .Name }}.class.getSimpleName().toLowerCase();

--- a/generate/controller_tpl.go
+++ b/generate/controller_tpl.go
@@ -114,6 +114,7 @@ public class {{ .Name }}Controller {
         log.debug("OrgId: {}, Client: {}", orgId, client);
 
         Event event = new Event(orgId, Constants.COMPONENT, {{ GetAction .Package }}.GET_ALL_{{ ToUpper .Name }}, client);
+        event.setOperation(Operation.READ);
         fintAuditService.audit(event);
         fintAuditService.audit(event, Status.CACHE);
 
@@ -144,6 +145,7 @@ public class {{ .Name }}Controller {
         log.debug("{{ $ident.Name }}: {}, OrgId: {}, Client: {}", id, orgId, client);
 
         Event event = new Event(orgId, Constants.COMPONENT, {{ GetAction $.Package }}.GET_{{ ToUpper $.Name }}, client);
+        event.setOperation(Operation.READ);
         event.setQuery("{{ $ident.Name }}/" + id);
 
         if (cacheService != null) {

--- a/generate/controller_tpl.go
+++ b/generate/controller_tpl.go
@@ -76,7 +76,7 @@ public class {{ .Name }}Controller {
     @GetMapping("/last-updated")
     public Map<String, String> getLastUpdated(@RequestHeader(name = HeaderConstants.ORG_ID, required = false) String orgId) {
         if (cacheService == null) {
-            throw new BadRequestException("Cache is disabled");
+            throw new CacheDisabledException("{{ .Name }} cache is disabled.");
         }
         if (props.isOverrideOrgId() || orgId == null) {
             orgId = props.getDefaultOrgId();
@@ -88,7 +88,7 @@ public class {{ .Name }}Controller {
     @GetMapping("/cache/size")
      public ImmutableMap<String, Integer> getCacheSize(@RequestHeader(name = HeaderConstants.ORG_ID, required = false) String orgId) {
         if (cacheService == null) {
-            throw new BadRequestException("Cache is disabled");
+            throw new CacheDisabledException("{{ .Name }} cache is disabled.");
         }
         if (props.isOverrideOrgId() || orgId == null) {
             orgId = props.getDefaultOrgId();
@@ -102,7 +102,7 @@ public class {{ .Name }}Controller {
             @RequestHeader(name = HeaderConstants.CLIENT, required = false) String client,
             @RequestParam(required = false) Long sinceTimeStamp) {
         if (cacheService == null) {
-            throw new BadRequestException("Cache is disabled");
+            throw new CacheDisabledException("{{ .Name }} cache is disabled.");
         }
         if (props.isOverrideOrgId() || orgId == null) {
             orgId = props.getDefaultOrgId();
@@ -295,9 +295,9 @@ public class {{ .Name }}Controller {
         return ResponseEntity.status(HttpStatus.FOUND).body(ErrorResponse.of(e));
     }
 
-    @ExceptionHandler(BadRequestException.class)
+    @ExceptionHandler(CacheDisabledException.class)
     public ResponseEntity handleBadRequest(Exception e) {
-        return ResponseEntity.badRequest().body(ErrorResponse.of(e));
+        return ResponseEntity.status(HttpStatus.SERVICE_UNAVAILABLE).body(ErrorResponse.of(e));
     }
 
     @ExceptionHandler(UnknownHostException.class)

--- a/generate/controller_tpl.go
+++ b/generate/controller_tpl.go
@@ -13,6 +13,7 @@ import no.fint.audit.FintAuditService;
 import no.fint.consumer.config.Constants;
 import no.fint.consumer.config.ConsumerProps;
 import no.fint.consumer.event.ConsumerEventUtil;
+import no.fint.consumer.event.SynchronousEvents;
 import no.fint.consumer.exceptions.*;
 import no.fint.consumer.status.StatusCache;
 import no.fint.consumer.utils.RestEndpoints;
@@ -164,7 +165,7 @@ public class {{ .Name }}Controller {
                     response.getData() == null ||
                     response.getData().isEmpty()) throw new EntityNotFoundException(id);
 
-            FakturagrunnlagResource data = objectMapper.convertValue(response.getData().get(0), FakturagrunnlagResource.class);
+            {{ $.Name }}Resource data = objectMapper.convertValue(response.getData().get(0), {{ $.Name }}Resource.class);
 
             fintAuditService.audit(event, Status.SENT_TO_CLIENT);
 

--- a/generate/controller_tpl.go
+++ b/generate/controller_tpl.go
@@ -140,10 +140,10 @@ public class {{ .Name }}Controller {
         if (client == null) {
             client = props.getDefaultClient();
         }
-        log.debug("{{ ToTitle $ident.Name }}: {}, OrgId: {}, Client: {}", id, orgId, client);
+        log.debug("{{ $ident.Name }}: {}, OrgId: {}, Client: {}", id, orgId, client);
 
         Event event = new Event(orgId, Constants.COMPONENT, {{ GetAction $.Package }}.GET_{{ ToUpper $.Name }}, client);
-        event.setQuery("{{ ToLower $ident.Name }}/" + id);
+        event.setQuery("{{ $ident.Name }}/" + id);
 
         if (cacheService != null) {
             fintAuditService.audit(event);

--- a/generate/controller_tpl.go
+++ b/generate/controller_tpl.go
@@ -165,11 +165,11 @@ public class {{ .Name }}Controller {
                     response.getData() == null ||
                     response.getData().isEmpty()) throw new EntityNotFoundException(id);
 
-            {{ $.Name }}Resource data = objectMapper.convertValue(response.getData().get(0), {{ $.Name }}Resource.class);
+            {{ $.Name }}Resource {{ ToLower $.Name }} = objectMapper.convertValue(response.getData().get(0), {{ $.Name }}Resource.class);
 
             fintAuditService.audit(event, Status.SENT_TO_CLIENT);
 
-            return linker.toResource(data);
+            return linker.toResource({{ ToLower $.Name }});
         }    
     }
 {{ end }}

--- a/generate/controller_tpl.go
+++ b/generate/controller_tpl.go
@@ -16,6 +16,7 @@ import no.fint.consumer.event.ConsumerEventUtil;
 import no.fint.consumer.event.SynchronousEvents;
 import no.fint.consumer.exceptions.*;
 import no.fint.consumer.status.StatusCache;
+import no.fint.consumer.utils.EventResponses;
 import no.fint.consumer.utils.RestEndpoints;
 
 import no.fint.event.model.*;
@@ -159,15 +160,14 @@ public class {{ .Name }}Controller {
             BlockingQueue<Event> queue = synchronousEvents.register(event);
             consumerEventUtil.send(event);
 
-            Event response = queue.poll(5, TimeUnit.MINUTES);
+            Event response = EventResponses.handle(queue.poll(5, TimeUnit.MINUTES));
 
-            if (response == null ||
-                    response.getData() == null ||
+            if (response.getData() == null ||
                     response.getData().isEmpty()) throw new EntityNotFoundException(id);
 
             {{ $.Name }}Resource {{ ToLower $.Name }} = objectMapper.convertValue(response.getData().get(0), {{ $.Name }}Resource.class);
 
-            fintAuditService.audit(event, Status.SENT_TO_CLIENT);
+            fintAuditService.audit(response, Status.SENT_TO_CLIENT);
 
             return linker.toResource({{ ToLower $.Name }});
         }    
@@ -275,6 +275,11 @@ public class {{ .Name }}Controller {
     //
     // Exception handlers
     //
+    @ExceptionHandler(EventResponseException.class)
+    public ResponseEntity handleEventResponseException(EventResponseException e) {
+        return ResponseEntity.status(e.getStatus()).body(e.getResponse());
+    }
+
     @ExceptionHandler(UpdateEntityMismatchException.class)
     public ResponseEntity handleUpdateEntityMismatch(Exception e) {
         return ResponseEntity.badRequest().body(ErrorResponse.of(e));


### PR DESCRIPTION
Enables support for disabling cache services for certain data classes by configuration.

For disabled cache services, fetching individual elements by ID results in `GET_ELEMENT` events to be dispatched to adapters, and the controller blocking for the adapter to respond.

The collection endpoint and cache control endpoints return `503` status.