### PR TITLE
Remove the /cache/rebuild endpoint.

### DIFF
--- a/generate/controller_tpl.go
+++ b/generate/controller_tpl.go
@@ -86,14 +86,6 @@ public class {{ .Name }}Controller {
         return ImmutableMap.of("size", cacheService.getAll(orgId).size());
     }
 
-    @PostMapping("/cache/rebuild")
-    public void rebuildCache(@RequestHeader(name = HeaderConstants.ORG_ID, required = false) String orgId) {
-        if (props.isOverrideOrgId() || orgId == null) {
-            orgId = props.getDefaultOrgId();
-        }
-        cacheService.rebuildCache(orgId);
-    }
-
     @GetMapping
     public {{ .Name }}Resources get{{ .Name }}(
             @RequestHeader(name = HeaderConstants.ORG_ID, required = false) String orgId,


### PR DESCRIPTION
This belongs under /admin, and should probably be restricted.

Relates to https://github.com/FINTLabs/fint-consumer-skeleton/pull/10