### PR TITLE
Delay initial cache fetch to the first update cycle.

### DIFF
--- a/setup/constants.go
+++ b/setup/constants.go
@@ -15,7 +15,7 @@ var funcMap = template.FuncMap{
 	"ToLower": strings.ToLower,
 	"ToUpper": strings.ToUpper,
 	"GetInitialRate": func(i int) string {
-		rate := (i * 10000) + 60000
+		rate := (i * 10000) + 900000
 		return strconv.Itoa(rate)
 	},
 }


### PR DESCRIPTION
This is assuming the consumer will bootstrap the initial build.

Related to https://github.com/FINTLabs/fint-consumer-skeleton/pull/6