### PR TITLE
Use HTTP 201 CREATED for success for updates.

### DIFF
--- a/generate/controller_tpl.go
+++ b/generate/controller_tpl.go
@@ -208,7 +208,7 @@ public class {{ .Name }}Controller {
                 URI location = UriComponentsBuilder.fromUriString(linker.getSelfHref(result.get(0))).build().toUri();
                 event.setMessage(location.toString());
                 fintAuditService.audit(event, Status.SENT_TO_CLIENT);
-                return ResponseEntity.status(HttpStatus.SEE_OTHER).location(location).build();
+                return ResponseEntity.created(location).body(linker.toResource(result.get(0)));
             case ERROR:
                 fintAuditService.audit(event, Status.SENT_TO_CLIENT);
                 return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(event.getResponse());


### PR DESCRIPTION
The rationale is to avoid the HTTP round trip that See Other requires from the Location header.
By using Created the resource can be returned immediately.
This enables the update flow to work even if the cache service has been disabled without requiring an additional `GET_` event roundtrip to the adapter.

This will deal with FINTLabs/fint-consumer-skeleton#8