### PR TITLE
Updated LinkMapper implementation to use parsed model

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,6 +1,3 @@
-#!/usr/bin/env sh
+#!/usr/bin/env bash
 
-
-rm -rf build
-
-gox -output="./build/{{.Dir}}-{{.OS}}" -rebuild -osarch="darwin/amd64 windows/amd64"
+docker build -t fint-consumer --build-arg VERSION=0.$(date +%y%m%d.%H%M) .

--- a/commands.go
+++ b/commands.go
@@ -49,7 +49,16 @@ var Commands = []cli.Command{
 		Name:   "generate",
 		Usage:  "generates consumer code",
 		Action: generate.CmdGenerate,
-		Flags:  []cli.Flag{},
+		Flags: []cli.Flag{
+			cli.StringFlag{
+				Name:  "component, c",
+				Usage: "component prefix, e.g. administrasjon",
+			},
+			cli.StringFlag{
+				Name:  "package, p",
+				Usage: "the package you want to create the consumer for, e.g. kodeverk",
+			},
+		},
 	},
 	{
 		Name:   "listPackages",

--- a/common/document/document.go
+++ b/common/document/document.go
@@ -5,21 +5,23 @@ import (
 	"os"
 
 	"github.com/FINTLabs/fint-consumer/common/github"
-	"github.com/antchfx/xquery/xml"
+	xmlquery "github.com/antchfx/xquery/xml"
 )
 
-func Get(owner string, repo string, tag string, filename string, force bool) *xmlquery.Node {
+func Get(owner string, repo string, tag string, filename string, force bool) (*xmlquery.Node, error) {
 
 	fileName := github.GetXMIFile(owner, repo, tag, filename, force)
 
 	f, err := os.Open(fileName)
 	if err != nil {
 		fmt.Println(err)
+		return nil, err
 	}
 	doc, err := xmlquery.Parse(f)
 	if err != nil {
 		fmt.Println(err)
+		return nil, err
 	}
-	return doc
+	return doc, nil
 
 }

--- a/common/parser/parser.go
+++ b/common/parser/parser.go
@@ -101,25 +101,33 @@ func GetClasses(owner string, repo string, tag string, filename string, force bo
 	fmt.Print(".")
 
 	for _, class := range classes {
-		for i, a := range class.Attributes {
-			if typ, found := classMap[a.Type]; found {
-				class.Attributes[i].Package = typ.Package
-				if typ.Resource {
-					class.Resources = append(class.Resources, a)
-				}
-			}
-		}
-	}
-
-	fmt.Print(".")
-
-	for _, class := range classes {
 		if len(class.Extends) > 0 {
 			if typ, found := classMap[class.Extends]; found {
 				class.ExtendsResource = typ.Resource || len(typ.Resources) > 0
 			}
 		}
 		class.InheritedAttributes = getAttributesFromExtends(class, classMap)
+	}
+
+	fmt.Print(".")
+
+	for _, class := range classes {
+		for i, a := range class.Attributes {
+			if typ, found := classMap[a.Type]; found {
+				class.Attributes[i].Package = typ.Package
+				if typ.Resource {
+					class.Resources = append(class.Resources, class.Attributes[i])
+				}
+			}
+		}
+		for i, a := range class.InheritedAttributes {
+			if typ, found := classMap[a.Type]; found {
+				class.InheritedAttributes[i].Package = typ.Package
+				if typ.Resource {
+					class.Resources = append(class.Resources, class.InheritedAttributes[i].Attribute)
+				}
+			}
+		}
 	}
 
 	fmt.Print(".")

--- a/common/types/association.go
+++ b/common/types/association.go
@@ -1,0 +1,11 @@
+package types
+
+type Association struct {
+	Name          string
+	Target        string
+	TargetPackage string
+	Deprecated    bool
+	Optional      bool
+	List          bool
+	Stereotype    string
+}

--- a/common/types/attribute.go
+++ b/common/types/attribute.go
@@ -1,9 +1,16 @@
 package types
 
 type Attribute struct {
-	Name     string
-	Type     string
-	List     bool
-	Optional bool
-	Writable bool
+	Name       string
+	Type       string
+	Package    string
+	List       bool
+	Optional   bool
+	Writable   bool
+	Deprecated bool
+}
+
+type InheritedAttribute struct {
+	Owner string
+	Attribute
 }

--- a/common/types/class.go
+++ b/common/types/class.go
@@ -1,17 +1,24 @@
 package types
 
 type Class struct {
-	Name             string
-	Abstract         bool
-	Extends          string
-	Package          string
-	Imports          []string
-	Namespace        string
-	Using            []string
-	DocumentationUrl string
-	Attributes       []Attribute
-	Relations        []string
-	Identifiable     bool
-	Writable         bool
-	Identifiers      []Identifier
+	Tag                 string
+	Name                string
+	Abstract            bool
+	Deprecated          bool
+	Extends             string
+	Package             string
+	Imports             []string
+	Namespace           string
+	Using               []string
+	Documentation       string
+	Attributes          []Attribute
+	InheritedAttributes []InheritedAttribute
+	Relations           []Association
+	Resources           []Attribute
+	Resource            bool
+	ExtendsResource     bool
+	Identifiable        bool
+	Writable            bool
+	Stereotype          string
+	Identifiers         []Identifier
 }

--- a/common/types/class.go
+++ b/common/types/class.go
@@ -1,5 +1,7 @@
 package types
 
+import "strings"
+
 type Class struct {
 	Tag                 string
 	Name                string
@@ -22,3 +24,9 @@ type Class struct {
 	Stereotype          string
 	Identifiers         []Identifier
 }
+
+type ByName []*Class
+
+func (n ByName) Len() int           { return len(n) }
+func (n ByName) Swap(i, j int)      { n[i], n[j] = n[j], n[i] }
+func (n ByName) Less(i, j int) bool { return strings.ToLower(n[i].Name) < strings.ToLower(n[j].Name) }

--- a/common/types/cs_types.go
+++ b/common/types/cs_types.go
@@ -8,6 +8,17 @@ var CS_TYPE_MAP = map[string]string{
 	"double":   "double",
 }
 
+var CS_VALUE_TYPES = []string{
+	"bool",
+	"byte",
+	"char",
+	"decimal",
+	"double",
+	"float",
+	"int",
+	"long",
+	"DateTime" }
+
 func GetCSType(t string) string {
 
 	value, ok := CS_TYPE_MAP[t]
@@ -16,4 +27,13 @@ func GetCSType(t string) string {
 	} else {
 		return t
 	}
+}
+
+func IsValueType(t string) bool {
+	for _, value := range CS_VALUE_TYPES {
+		if t == value {
+			return true
+		}
+	}
+	return false
 }

--- a/common/types/identifier.go
+++ b/common/types/identifier.go
@@ -1,6 +1,6 @@
 package types
 
 type Identifier struct {
-	Name string
+	Name     string
 	Optional bool
 }

--- a/common/types/java_types.go
+++ b/common/types/java_types.go
@@ -1,11 +1,18 @@
 package types
 
 var JAVA_TYPE_MAP = map[string]string{
-	"string":   "String",
-	"boolean":  "boolean",
-	"date":     "Date",
-	"dateTime": "Date",
-	"double":   "double",
+	"string":      "String",
+	"boolean":     "Boolean",
+	"date":        "Date",
+	"dateTime":    "Date",
+	"float":       "Float",
+	"double":      "Double",
+	"long":        "Long",
+	"int":         "Integer",
+	"hovedklasse": "FintMainObject",
+	"referanse":   "FintReference",
+	"abstrakt":    "FintAbstractObject",
+	"datatype":    "FintComplexDatatypeObject",
 }
 
 func GetJavaType(t string) string {

--- a/generate/cache_service_tpl.go
+++ b/generate/cache_service_tpl.go
@@ -31,7 +31,7 @@ import java.util.stream.Collectors;
 import {{ .Package }}.{{ .Name }};
 import {{ resourcePkg .Package }}.{{ .Name }}Resource;
 import {{ GetActionPackage .Package }};
-import {{ GetIdentifikatorPackage .Imports }};
+import {{ GetIdentifikatorPackage .Attributes .InheritedAttributes }};
 
 @Slf4j
 @Service

--- a/generate/command.go
+++ b/generate/command.go
@@ -15,6 +15,6 @@ func CmdGenerate(c *cli.Context) {
 	}
 	force := c.GlobalBool("force")
 
-	Generate(c.GlobalString("owner"), c.GlobalString("repo"), tag, c.GlobalString("filename"), force, c.String("component"), c.String("package"))
+	Generate(c.GlobalString("owner"), c.GlobalString("repo"), tag, c.GlobalString("filename"), force, c.String("component"), c.String("package"), false)
 
 }

--- a/generate/command.go
+++ b/generate/command.go
@@ -15,6 +15,6 @@ func CmdGenerate(c *cli.Context) {
 	}
 	force := c.GlobalBool("force")
 
-	Generate(c.GlobalString("owner"), c.GlobalString("repo"), tag, c.GlobalString("filename"), force)
+	Generate(c.GlobalString("owner"), c.GlobalString("repo"), tag, c.GlobalString("filename"), force, c.String("component"), c.String("package"))
 
 }

--- a/generate/generator.go
+++ b/generate/generator.go
@@ -69,8 +69,6 @@ func Generate(owner string, repo string, tag string, filename string, force bool
 		fmt.Println(err)
 	}
 
-	var resources []*types.Class
-	var attributes = make(map[string]bool)
 	var classMap = make(map[string]*types.Class)
 
 	classes, _, _, _ := parser.GetClasses(owner, repo, tag, filename, force)
@@ -78,9 +76,16 @@ func Generate(owner string, repo string, tag string, filename string, force bool
 		classMap[c.Package+"."+c.Name] = c
 	}
 
+	var pkgName = "." + component
+	if len(pkg) > 0 {
+		pkgName = pkgName + "." + pkg
+	}
+	var resources []*types.Class
+	var attributes = make(map[string]bool)
+
 	for _, c := range classes {
 
-		if (strings.Contains(c.Package, component+"."+pkg) && !c.Abstract && c.Identifiable) ||
+		if (strings.Contains(c.Package, pkgName) && !c.Abstract && c.Identifiable) ||
 			(includePerson && (c.Name == "Person" || c.Name == "Kontaktperson")) {
 			fmt.Printf("  > Creating consumer package and classes for: %s.%s\n", c.Package, c.Name)
 

--- a/generate/generator.go
+++ b/generate/generator.go
@@ -18,10 +18,15 @@ var funcMap = template.FuncMap{
 	"ToLower": strings.ToLower,
 	"ToUpper": strings.ToUpper,
 	"ToTitle": strings.Title,
-	"GetIdentifikatorPackage": func(imp []string) string {
-		for _, p := range imp {
-			if strings.HasSuffix(p, ".Identifikator") {
-				return p
+	"GetIdentifikatorPackage": func(attr []types.Attribute, inh []types.InheritedAttribute) string {
+		for _, a := range attr {
+			if a.Type == "Identifikator" {
+				return a.Package + "." + a.Type
+			}
+		}
+		for _, a := range inh {
+			if a.Type == "Identifikator" {
+				return a.Package + "." + a.Type
 			}
 		}
 		return "java.util.Random"

--- a/setup/command.go
+++ b/setup/command.go
@@ -44,13 +44,11 @@ func CmdSetupConsumer(c *cli.Context) {
 	version := c.String("version")
 
 	setupSkeleton(name, ref)
-	resources := generate.Generate(c.GlobalString("owner"), c.GlobalString("repo"), tag, c.GlobalString("filename"), force, component, pkg)
+	includePerson := c.Bool("includePerson")
+	resources := generate.Generate(c.GlobalString("owner"), c.GlobalString("repo"), tag, c.GlobalString("filename"), force, component, pkg, includePerson)
 	sort.Sort(types.ByName(resources))
 
 	addModels(component, pkg, name)
-
-	includePerson := c.Bool("includePerson")
-	addPerson(includePerson, name)
 
 	updateConfigFiles(component, pkg, name, resources)
 
@@ -149,24 +147,6 @@ func addModels(component string, pkg string, name string) {
 		fmt.Println(err)
 	}
 }
-func addPerson(includePerson bool, name string) {
-	if includePerson {
-		src := fmt.Sprintf("%s/%s/felles/person", utils.GetTempDirectory(), config.BASE_PATH)
-		dest := fmt.Sprintf("./%s/src/main/java/no/fint/consumer/models/person/", getConsumerName(name))
-		err := utils.CopyDir(src, dest)
-		if err != nil {
-			fmt.Println(err)
-		}
-
-		src = fmt.Sprintf("%s/%s/felles/kontaktperson", utils.GetTempDirectory(), config.BASE_PATH)
-		dest = fmt.Sprintf("./%s/src/main/java/no/fint/consumer/models/kontaktperson/", getConsumerName(name))
-		err = utils.CopyDir(src, dest)
-		if err != nil {
-			fmt.Println(err)
-		}
-	}
-}
-
 func addModelToGradle(model string, name string) {
 	m := fmt.Sprintf("    compile(\"no.fint:fint-%s-resource-model-java:${apiVersion}\")", model)
 	gradleFile := utils.GetGradleFile(getConsumerName(name))

--- a/setup/command.go
+++ b/setup/command.go
@@ -5,7 +5,7 @@ import (
 	"io/ioutil"
 	"log"
 	"os"
-	"path/filepath"
+	"sort"
 	"strings"
 
 	"github.com/FINTLabs/fint-consumer/common/config"
@@ -45,6 +45,7 @@ func CmdSetupConsumer(c *cli.Context) {
 
 	setupSkeleton(name, ref)
 	resources := generate.Generate(c.GlobalString("owner"), c.GlobalString("repo"), tag, c.GlobalString("filename"), force, component, pkg)
+	sort.Sort(types.ByName(resources))
 
 	addModels(component, pkg, name)
 

--- a/setup/command.go
+++ b/setup/command.go
@@ -120,7 +120,7 @@ func updateConfigFiles(component string, pkg string, name string, resources []*t
 	assocs := getAssociationsFromResources(resources)
 	/*writeConsumerPropsFile(getConsumerPropsClass(models), name)*/
 	writeConstantsFile(getConstantsClass(name, models), name)
-	writeLinkMapperFile(getLinkMapperClass(component, pkg, models, assocs), name)
+	writeLinkMapperFile(getLinkMapperClass(models, assocs), name)
 	writeRestEndpointsFile(getRestEndpointsClass(models), name)
 }
 func addModels(component string, pkg string, name string) {

--- a/setup/command.go
+++ b/setup/command.go
@@ -99,9 +99,12 @@ func getAssociationsFromResources(resources []*types.Class) []types.Association 
 	var assocs = []types.Association{}
 	var exists = make(map[string]struct{})
 	for _, c := range resources {
+		exists[c.Name] = struct{}{}
+	}
+	for _, c := range resources {
 		for _, rel := range c.Relations {
 			//fmt.Printf("Considering %s.%s -> %s.%s...\n", c.Name, rel.Name, rel.TargetPackage, rel.Target)
-			if c.Package != rel.TargetPackage && rel.Stereotype == "hovedklasse" && rel.Target != "Person" {
+			if rel.Stereotype == "hovedklasse" {
 				_, ok := exists[rel.Target]
 				if !ok {
 					assocs = append(assocs, rel)

--- a/setup/constants.go
+++ b/setup/constants.go
@@ -15,7 +15,7 @@ var funcMap = template.FuncMap{
 	"ToLower": strings.ToLower,
 	"ToUpper": strings.ToUpper,
 	"GetInitialRate": func(i int) string {
-		rate := (i * 60000) + 900000
+		rate := (i * 100000) + 900000
 		return strconv.Itoa(rate)
 	},
 }

--- a/setup/constants_tpl.go
+++ b/setup/constants_tpl.go
@@ -1,7 +1,6 @@
 package setup
 
-const CONSTANTS_TEMPLATE = `
-package no.fint.consumer.config;
+const CONSTANTS_TEMPLATE = `package no.fint.consumer.config;
 
 public enum Constants {
 ;
@@ -11,8 +10,8 @@ public enum Constants {
     public static final String CACHE_SERVICE = "CACHE_SERVICE";
 
 {{ range $i, $model := .Models }}    
-    public static final String CACHE_INITIALDELAY_{{ ToUpper .Name }} = "${fint.consumer.cache.initialDelay.{{ .Name }}:{{ GetInitialRate $i }}}";
-    public static final String CACHE_FIXEDRATE_{{ ToUpper .Name }} = "${fint.consumer.cache.fixedRate.{{ .Name }}:900000}";
+    public static final String CACHE_INITIALDELAY_{{ ToUpper .Name }} = "${fint.consumer.cache.initialDelay.{{ ToLower .Name }}:{{ GetInitialRate $i }}}";
+    public static final String CACHE_FIXEDRATE_{{ ToUpper .Name }} = "${fint.consumer.cache.fixedRate.{{ ToLower .Name }}:900000}";
 {{end }}    
 
 }

--- a/setup/linkmapper.go
+++ b/setup/linkmapper.go
@@ -11,7 +11,7 @@ import (
 	"github.com/FINTLabs/fint-consumer/generate"
 )
 
-func getLinkMapperClass(component string, pkg string, models []types.Model, assocs []types.Association) string {
+func getLinkMapperClass(models []types.Model, assocs []types.Association) string {
 	var funcMap = template.FuncMap{
 		"ToLower": strings.ToLower,
 		"ToUpper": strings.ToUpper,
@@ -27,13 +27,9 @@ func getLinkMapperClass(component string, pkg string, models []types.Model, asso
 	}
 
 	m := struct {
-		Component string
-		Package   string
-		Models    []types.Model
-		Assocs    []types.Association
+		Models []types.Model
+		Assocs []types.Association
 	}{
-		component,
-		pkg,
 		models,
 		assocs,
 	}

--- a/setup/linkmapper.go
+++ b/setup/linkmapper.go
@@ -8,13 +8,15 @@ import (
 	"text/template"
 
 	"github.com/FINTLabs/fint-consumer/common/types"
+	"github.com/FINTLabs/fint-consumer/generate"
 )
 
-func getLinkMapperClass(component string, pkg string, models []types.Model) string {
+func getLinkMapperClass(component string, pkg string, models []types.Model, assocs []types.Association) string {
 	var funcMap = template.FuncMap{
 		"ToLower": strings.ToLower,
 		"ToUpper": strings.ToUpper,
 		"ToTitle": strings.Title,
+		"ToUri":   generate.GetMainPackage,
 	}
 	tpl := template.New("class").Funcs(funcMap)
 
@@ -28,10 +30,12 @@ func getLinkMapperClass(component string, pkg string, models []types.Model) stri
 		Component string
 		Package   string
 		Models    []types.Model
+		Assocs    []types.Association
 	}{
 		component,
 		pkg,
 		models,
+		assocs,
 	}
 
 	var b bytes.Buffer

--- a/setup/linkmapper_tpl.go
+++ b/setup/linkmapper_tpl.go
@@ -6,10 +6,8 @@ import no.fint.consumer.utils.RestEndpoints;
 import java.util.Map;
 import com.google.common.collect.ImmutableMap;
 
-{{ if .Package -}}
-import no.fint.model.{{.Component}}.{{.Package}}.*;
-{{- else -}}
-import no.fint.model.{{.Component}}.*;
+{{- range $i, $model := .Models }}
+import {{.Package}}.{{.Name}};
 {{- end }}
 
 public class LinkMapper {

--- a/setup/linkmapper_tpl.go
+++ b/setup/linkmapper_tpl.go
@@ -14,14 +14,17 @@ import no.fint.model.{{.Component}}.*;
 
 public class LinkMapper {
 
-	public static Map<String, String> linkMapper(String contextPath) {
-		return ImmutableMap.<String,String>builder()
-		{{- range $i, $model := .Models }}
-			.put({{ ToTitle .Name }}.class.getName(), contextPath + RestEndpoints.{{ ToUpper .Name }})
-		{{- end }}
-			/* .put(TODO,TODO) */
-			.build();
-	}
+    public static Map<String, String> linkMapper(String contextPath) {
+        return ImmutableMap.<String,String>builder()
+        {{- range $i, $model := .Models }}
+            .put({{ ToTitle .Name }}.class.getName(), contextPath + RestEndpoints.{{ ToUpper .Name }})
+        {{- end }}
+        {{- range $i, $assoc := .Assocs }}
+            .put("{{ .TargetPackage }}.{{ .Target }}", "/{{ ToUri .TargetPackage }}/{{ ToLower .Target }}")
+        {{- end }}
+            /* .put(TODO,TODO) */
+            .build();
+    }
 
 }
 `


### PR DESCRIPTION
This PR updates the LinkMapper generator to use the parsed model instead of traversing the file structure.

It then is able to properly retain the casing of the class names.

In addition, it generates mappings for all outbound relations.

The parser is copied from fint-jsonschema.

TODO:
- [x] incorporate `includePerson`
- [x] exclude internal relations when mapping outbound relations.
- [x] import of `Identifikator` in `CacheService`
- [x] naming of properties in `Constants`